### PR TITLE
Pass batch size and workers to val loader

### DIFF
--- a/main_ce.py
+++ b/main_ce.py
@@ -161,8 +161,8 @@ def set_loader(opt):
         train_dataset, batch_size=opt.batch_size, shuffle=(train_sampler is None),
         num_workers=opt.num_workers, pin_memory=True, sampler=train_sampler)
     val_loader = torch.utils.data.DataLoader(
-        val_dataset, batch_size=256, shuffle=False,
-        num_workers=8, pin_memory=True)
+        val_dataset, batch_size=opt.batch_size, shuffle=False,
+        num_workers=opt.num_workers, pin_memory=True)
 
     return train_loader, val_loader
 


### PR DESCRIPTION
pass opt.batch_size and opt.workers to val_loader

These parameters were not passed to the val_loader, which may result in this issue.https://github.com/HobbitLong/SupContrast/issues/71